### PR TITLE
添加 MiniMax H3 1K 提示词数据集到 AI 文生视频模型

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@
 | [doubao-seedance-ttv-itv](https://github.com/wwwzhouhui/doubao-seedance-ttv-itv) | ![](https://img.shields.io/github/stars/wwwzhouhui/doubao-seedance-ttv-itv?style=flat-square) | 豆包 Seedance 1.5 Pro 视频生成工具，支持文生视频和图生视频，提供 Gradio Web UI 和 RESTful API。 |
 | [daihuo-jianshou](https://github.com/xixihhhh/daihuo-jianshou) | ![](https://img.shields.io/github/stars/xixihhhh/daihuo-jianshou?style=flat-square) | AI 电商带货视频生成工具 — 上传商品图自动生成抖音/快手/小红书带货短视频，AI 脚本+生图+合成一条龙，支持 Seedance 2.0 / GPT Image 2 / Kling 3.0 / Veo 3 等模型。 |
 | [video-clipforge](https://github.com/Johnson-Jia/video-clipforge) | ![](https://img.shields.io/github/stars/Johnson-Jia/video-clipforge?style=flat-square) | AI 驱动的短视频制作系统。给它一个想法，它帮你写稿、配音、做画面、出成片。9 阶段 DAG 管线 + 自进化评分，支持每日自动执行。基于 Claude Code + HyperFrames。 |
+| [MiniMax H3 1K 提示词数据集](https://neta.art/use-cases/en/h3-1000-prompt-list) | ![](https://img.shields.io/github/stars/yangzhou-chaofan/minimax-h3-1000-prompts?style=flat-square) | MiniMax H3 文生视频提示词数据集 — 1,000 条精选提示词、3 字段结构拆解、10 条可复用提示词、H3 与竞品对比 |
 
 ## 自媒体运营工具
 


### PR DESCRIPTION
在该仓库收集的 AI 文生视频模型旁边，这份精选的 1K 条文生视频提示词数据集是天然的配套资源：3 字段提示词结构拆解、10 条可复用提示词、H3 与竞品模型对比。\n\nLinks:\n- Interactive atlas of all 1,000 H3 clips: https://neta.art/use-cases/en/h3-1000-prompt-list\n- Curated index repo: https://github.com/yangzhou-chaofan/minimax-h3-1000-prompts\n- Original dataset (ostris/minimax_h3_1k): https://huggingface.co/datasets/ostris/minimax_h3_1k